### PR TITLE
Add top-level redirect to GitHub site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="3;URL='https://github.com/soft-matter/'" />
+  </head>
+  <body>
+      Redirecting to the "soft-matter" page on GitHub that lists our projects.
+  </body>
+<html>


### PR DESCRIPTION
Currently, visitors to http://soft-matter.github.io/ get a 404. This replaces it with something more useful.
