### PR TITLE
Exclude old docs versions from search engine indexing

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Disallow: /trackpy/0.3.0/
+Disallow: /trackpy/v0.2.4/
+Disallow: /trackpy/v0.3.1/
+Disallow: /trackpy/v0.3.2/
+Disallow: /trackpy/v0.3.3/
+


### PR DESCRIPTION
This is an attempt to fix https://github.com/soft-matter/trackpy/issues/536 by excluding old versions of the trackpy docs from search engine indexing. Note that crawlers like the Internet Archive do not read `robots.txt`, so we are not trying to make old versions forgotten; we just don't want them showing up in search results for "trackpy".

I'm not sure exactly how the Travis auto-build works, but hopefully it will not wipe out this change once merged.